### PR TITLE
Moving "vim" under "Text editor" and merging the "Programming" section to "Others"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,57 +5,55 @@ All you need is one link to become a pro in some area. Here is a list of all the
 The first 20 hours: https://www.youtube.com/watch?v=5MgBikgcWnY
 
 ## JavaScript
-* JavaScript: http://speakingjs.com/es5/index.html
+* **JavaScript**: http://speakingjs.com/es5/index.html
 	* ES6 (after you understand the fundamental JS materials): https://ponyfoo.com/articles/es6
 	* JS Style: https://github.com/airbnb/javascript
 	* JS Pattern: https://addyosmani.com/resources/essentialjsdesignpatterns/book/
-* Front-end development
+* **Front-end development**
 	* Part 1: https://medium.freecodecamp.com/from-zero-to-front-end-hero-part-1-7d4f7f0bff02
 	* Part 2: https://medium.freecodecamp.com/from-zero-to-front-end-hero-part-2-adfa4824da9b
-* ReactJS: http://courses.reactjsprogram.com/courses/reactjsfundamentals
-* Redux (after knowing ReactJS): https://learnredux.com
-* React Native: https://facebook.github.io/react-native/docs/tutorial.html
-* AngularJS: https://toddmotto.com/ultimate-guide-to-learning-angular-js-in-one-day/
-* NodeJS: https://www.codeschool.com/courses/real-time-web-with-node-js
-* jQuery: http://jqfundamentals.com
-* HTML & CSS (related to JS): http://learn.shayhowe.com/html-css/
+* **ReactJS**: http://courses.reactjsprogram.com/courses/reactjsfundamentals
+* **Redux** (after knowing ReactJS): https://learnredux.com
+* **React Native**: https://facebook.github.io/react-native/docs/tutorial.html
+* **AngularJS**: https://toddmotto.com/ultimate-guide-to-learning-angular-js-in-one-day/
+* **NodeJS**: https://www.codeschool.com/courses/real-time-web-with-node-js
+* **jQuery**: http://jqfundamentals.com
+* **HTML & CSS** (related to JS): http://learn.shayhowe.com/html-css/
 
 ## Languages
-* Scala: http://twitter.github.io/scala_school/
-* Go: https://astaxie.gitbooks.io/build-web-application-with-golang/content/en/preface.html
-* Ruby on Rails: https://www.railstutorial.org/book
-* Rust: https://doc.rust-lang.org/book/
-* Lua: http://nova-fusion.com/2012/08/27/lua-for-programmers-part-1/
-* Kotlin: http://kotlinlang.org/docs/reference/
-* PHP: http://www.phptherightway.com/
-* C++ STL
+* **Scala**: http://twitter.github.io/scala_school/
+* **Go**: https://astaxie.gitbooks.io/build-web-application-with-golang/content/en/preface.html
+* **Ruby on Rails**: https://www.railstutorial.org/book
+* **Rust**: https://doc.rust-lang.org/book/
+* **Lua**: http://nova-fusion.com/2012/08/27/lua-for-programmers-part-1/
+* **Kotlin**: http://kotlinlang.org/docs/reference/
+* **PHP**: http://www.phptherightway.com/
+* **C++ STL**
 	* Part 1: https://www.topcoder.com/community/data-science/data-science-tutorials/power-up-c-with-the-standard-template-library-part-1/
 	* Part 2: https://www.topcoder.com/community/data-science/data-science-tutorials/power-up-c-with-the-standard-template-library-part-2/
 
-## Programming
-* Interview: https://leetcode.com
-* ICPC: http://www.stanford.edu/class/cs97si/
-
 ## Mobile
-* iOS with Swift: https://itunes.apple.com/us/course/developing-ios-9-apps-swift/id1104579961
+* **iOS with Swift**: https://itunes.apple.com/us/course/developing-ios-9-apps-swift/id1104579961
 
 ## Tools
-* Git: http://marc.helbling.fr/2014/09/practical-git-introduction
-* Text Editor: http://www.learnenough.com/text-editor-tutorial
-* Markdown: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet
-* LaTex: http://www.latex-tutorial.com/tutorials/
-* Vim: http://learnvimscriptthehardway.stevelosh.com/
+* **Git**: http://marc.helbling.fr/2014/09/practical-git-introduction
+* **Text Editor**: http://www.learnenough.com/text-editor-tutorial
+	* Vim: http://learnvimscriptthehardway.stevelosh.com/
+* **Markdown**: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet
+* **LaTex**: http://www.latex-tutorial.com/tutorials/
 
 ## Others
-* Hacking: https://www.hacksplaining.com
-* Design: https://medium.com/hh-design/design-resources-5071be5f2e43
-* Machine Learning: https://www.coursera.org/learn/machine-learning
-* Neural Networks: http://neuralnetworksanddeeplearning.com/index.html
-* Deep Learning: http://www.deeplearningbook.org/
-* Game Programming: http://www-cs-students.stanford.edu/%7Eamitp/gameprog.html
-* Cryptography: https://www.crypto101.io
-* Networking: http://beej.us/guide/bgnet/output/html/multipage/index.html
-* Data Mining: http://guidetodatamining.com/
+* **Interview**: https://leetcode.com
+* **Hacking**: https://www.hacksplaining.com
+* **Design**: https://medium.com/hh-design/design-resources-5071be5f2e43
+* **Machine Learning**: https://www.coursera.org/learn/machine-learning
+* **Neural Networks**: http://neuralnetworksanddeeplearning.com/index.html
+* **Deep Learning**: http://www.deeplearningbook.org/
+* **Game Programming**: http://www-cs-students.stanford.edu/%7Eamitp/gameprog.html
+* **Cryptography**: https://www.crypto101.io
+* **Networking**: http://beej.us/guide/bgnet/output/html/multipage/index.html
+* **Data Mining**: http://guidetodatamining.com/
+* **ICPC**: http://www.stanford.edu/class/cs97si/
 
 # Contribute to this list
 If you would like to contribute to this list you can reach out to me via email, twitter, or fork this repository and make a pull request.


### PR DESCRIPTION
Merging the "Programming" section into "Others" because the whole article is already about programming, so making a programming section into a programming article is a bit far-fetched - plus the fact that the Programming section only had 2 items.

Also moved "Vim" under "Text editor" as a subcategory (because Vim IS a text editor).
