### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The first 20 hours: https://www.youtube.com/watch?v=5MgBikgcWnY
 * Design Patterns: https://sourcemaking.com/design_patterns
 * Data Visualization: http://alignedleft.com/tutorials/d3
 
-#FAQ
+# FAQ
 **How is this repo different from [awesome](https://github.com/sindresorhus/awesome)?**
 
 This repo is maintained as a list of one-hit KO of topics.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
